### PR TITLE
Add workout session and template stats pages

### DIFF
--- a/ClientApp/src/features/trainings/history/components/WorkoutHistoryCard.tsx
+++ b/ClientApp/src/features/trainings/history/components/WorkoutHistoryCard.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import {
+  BarChart3,
   Clock,
   Eye,
   Flame,
@@ -7,6 +8,7 @@ import {
   MoreVertical,
   SlidersHorizontal,
 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -119,6 +121,16 @@ export function WorkoutHistoryCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuItem asChild>
+                <Link
+                  to="/trainings/workout-session-stats/$ongoingTrainingId"
+                  params={{ ongoingTrainingId: workout.id }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <BarChart3 className="mr-2 h-4 w-4" />
+                  Workout stats
+                </Link>
+              </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={(e) => {
                   e.stopPropagation();

--- a/ClientApp/src/features/trainings/overview/components/TrainingTemplatesChart.tsx
+++ b/ClientApp/src/features/trainings/overview/components/TrainingTemplatesChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Bar,
   BarChart,
@@ -19,6 +20,7 @@ import { trainingTemplatesUsageQueryOptions } from "../queries/useTrainingTempla
 import { useOverviewDateRange } from "../contexts/OverviewDateRangeContext";
 
 function TrainingTemplatesChart() {
+  const navigate = useNavigate();
   const { startDate, endDate } = useOverviewDateRange();
 
   const { query: templatesQuery, isDelayedFetching } = useCustomQuery(
@@ -30,6 +32,7 @@ function TrainingTemplatesChart() {
       return [];
     }
     return templatesQuery.data.map((template) => ({
+      trainingId: template.trainingId,
       name: template.trainingName,
       fullyCompleted: template.totalFullyCompleted,
       withSkippedExercises: template.totalWithSkippedExercises,
@@ -37,16 +40,29 @@ function TrainingTemplatesChart() {
     }));
   }, [templatesQuery.data]);
 
+  const handleBarClick = (data: unknown) => {
+    const row = data as { trainingId?: string };
+    if (row?.trainingId) {
+      navigate({
+        to: "/trainings/workout-template-stats/$workoutId",
+        params: { workoutId: row.trainingId },
+      });
+    }
+  };
+
   return (
     <Card>
       <CardHeader>
         <div className="flex flex-col items-center justify-center gap-2 sm:flex-row sm:justify-between">
           <CardTitle className="text-xl">Trainings Completion Rate</CardTitle>
+          <p className="text-center text-xs text-muted-foreground sm:text-right">
+            Click a bar to open stats for that template.
+          </p>
         </div>
       </CardHeader>
       <CardContent className="relative px-3 py-4">
         <ResponsiveContainer width="100%" height={400}>
-          <BarChart data={chartData}>
+          <BarChart data={chartData} className="cursor-pointer [&_.recharts-bar-rectangle]:cursor-pointer">
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis
               dataKey="name"
@@ -69,11 +85,13 @@ function TrainingTemplatesChart() {
               dataKey="fullyCompleted"
               fill={colors.green}
               name="Fully completed"
+              onClick={handleBarClick}
             />
             <Bar
               dataKey="withSkippedExercises"
               fill={colors.blue}
               name="With skipped exercises"
+              onClick={handleBarClick}
             />
           </BarChart>
         </ResponsiveContainer>

--- a/ClientApp/src/features/trainings/trainings/components/trainingsList/TrainingListItem.tsx
+++ b/ClientApp/src/features/trainings/trainings/components/trainingsList/TrainingListItem.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
+  BarChart2,
   Clock,
   MoreVertical,
   Pencil,
@@ -80,6 +81,31 @@ function TrainingListItem({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  disabled={
+                    training.isLoading ||
+                    training.isDeleting ||
+                    createOngoingTrainingMutation.isPending ||
+                    deleteOngoingTrainingMutation.isPending
+                  }
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    navigate({
+                      to: "/trainings/workout-template-stats/$workoutId",
+                      params: { workoutId: training.id },
+                    });
+                  }}
+                  onPointerEnter={() => {
+                    router.preloadRoute({
+                      to: "/trainings/workout-template-stats/$workoutId",
+                      params: { workoutId: training.id },
+                    });
+                  }}
+                >
+                  <BarChart2 className="mr-2 h-4 w-4" />
+                  Stats
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   className="cursor-pointer"
                   disabled={

--- a/ClientApp/src/lib/workoutSessionStats.ts
+++ b/ClientApp/src/lib/workoutSessionStats.ts
@@ -1,0 +1,93 @@
+import type { ExerciseSet, OngoingTrainingDto } from "@/services/openapi";
+
+/**
+ * Set lines and totals below use `OngoingTrainingDto.training.exercises[].exerciseSets`
+ * (the snapshot embedded on the session). Per-exercise adjustments during a live workout
+ * are stored separately in exercise history (old vs new set JSON); a future read model or
+ * endpoint could merge those for “final logged” stats without changing this heuristic layer.
+ */
+export type WorkoutSessionDerivedStats = {
+  totalExercises: number;
+  completedCount: number;
+  skippedCount: number;
+  skipRatePercent: number;
+  completionRatePercent: number;
+  totalSetsCompleted: number;
+  /** Sum of count1×count2 when count2 is set, else count1 (numeric only). */
+  volumeHeuristic: number;
+  /** Sum of per-set restTimeSeconds on completed exercises’ sets. */
+  plannedRestSecondsFromSets: number;
+  /** actual duration / (planned template duration in minutes × 60); null if not comparable. */
+  pacingRatioVsPlanned: number | null;
+  actualDurationSeconds: number | null;
+};
+
+function volumeForSet(set: ExerciseSet): number {
+  const c1 = set.count1;
+  const c2 = set.count2;
+  if (c2 != null && Number.isFinite(c1) && Number.isFinite(c2)) {
+    return c1 * c2;
+  }
+  return Number.isFinite(c1) ? c1 : 0;
+}
+
+export function deriveWorkoutSessionStats(
+  ongoing: OngoingTrainingDto,
+): WorkoutSessionDerivedStats {
+  const exercises = ongoing.training.exercises ?? [];
+  const totalExercises = exercises.length;
+  const completedIds = new Set(ongoing.completedExerciseIds ?? []);
+  const skippedIds = new Set(ongoing.skippedExerciseIds ?? []);
+  const completedCount = completedIds.size;
+  const skippedCount = skippedIds.size;
+
+  const skipRatePercent =
+    totalExercises > 0 ? (skippedCount / totalExercises) * 100 : 0;
+  const completionRatePercent =
+    totalExercises > 0 ? (completedCount / totalExercises) * 100 : 0;
+
+  let totalSetsCompleted = 0;
+  let volumeHeuristic = 0;
+  let plannedRestSecondsFromSets = 0;
+
+  for (const ex of exercises) {
+    if (!completedIds.has(ex.id)) {
+      continue;
+    }
+    const sets = ex.exerciseSets ?? [];
+    totalSetsCompleted += sets.length;
+    for (const set of sets) {
+      volumeHeuristic += volumeForSet(set);
+      if (typeof set.restTimeSeconds === "number") {
+        plannedRestSecondsFromSets += set.restTimeSeconds;
+      }
+    }
+  }
+
+  let actualDurationSeconds: number | null = null;
+  let pacingRatioVsPlanned: number | null = null;
+  if (ongoing.finishedOnUtc && ongoing.startedOnUtc) {
+    const ms =
+      new Date(ongoing.finishedOnUtc).getTime() -
+      new Date(ongoing.startedOnUtc).getTime();
+    actualDurationSeconds = Math.max(0, Math.round(ms / 1000));
+    const plannedMinutes = ongoing.training.duration;
+    if (plannedMinutes > 0 && actualDurationSeconds != null) {
+      const plannedSeconds = plannedMinutes * 60;
+      pacingRatioVsPlanned = actualDurationSeconds / plannedSeconds;
+    }
+  }
+
+  return {
+    totalExercises,
+    completedCount,
+    skippedCount,
+    skipRatePercent,
+    completionRatePercent,
+    totalSetsCompleted,
+    volumeHeuristic,
+    plannedRestSecondsFromSets,
+    pacingRatioVsPlanned,
+    actualDurationSeconds,
+  };
+}

--- a/ClientApp/src/pages/trainings/WorkoutFinishedPage.tsx
+++ b/ClientApp/src/pages/trainings/WorkoutFinishedPage.tsx
@@ -1,7 +1,8 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import {
   ArrowLeft,
+  BarChart3,
   CheckCircle2,
   Clock,
   Dumbbell,
@@ -135,14 +136,28 @@ function WorkoutFinished() {
                 </div>
               </div>
 
-              {/* Back to Home Button */}
-              <Button
-                onClick={handleBackToHome}
-                className="h-12 w-full gap-2 bg-primary font-semibold text-primary-foreground hover:bg-primary/90"
-              >
-                <ArrowLeft className="h-4 w-4" />
-                Back to Home
-              </Button>
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="outline"
+                  className="h-12 w-full gap-2"
+                  asChild
+                >
+                  <Link
+                    to="/trainings/workout-session-stats/$ongoingTrainingId"
+                    params={{ ongoingTrainingId: params.ongoingTrainingId }}
+                  >
+                    <BarChart3 className="h-4 w-4" />
+                    View workout stats
+                  </Link>
+                </Button>
+                <Button
+                  onClick={handleBackToHome}
+                  className="h-12 w-full gap-2 bg-primary font-semibold text-primary-foreground hover:bg-primary/90"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Back to Home
+                </Button>
+              </div>
             </CardContent>
           </Card>
 

--- a/ClientApp/src/pages/trainings/WorkoutSessionStatsPage.tsx
+++ b/ClientApp/src/pages/trainings/WorkoutSessionStatsPage.tsx
@@ -1,0 +1,206 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import {
+  ArrowLeft,
+  BarChart3,
+  CheckCircle2,
+  Clock,
+  Dumbbell,
+  Flame,
+  Layers,
+  MinusCircle,
+  Timer,
+  TrendingUp,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+
+import PageCard from "@/components/common/PageCard";
+import PageTitle from "@/components/common/PageTitle";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ongoingTrainingsQueryOptions } from "@/features/trainings/ongoing-workout/queries/ongoingTrainingsQuery";
+import { deriveWorkoutSessionStats } from "@/lib/workoutSessionStats";
+import { formatDurationMs } from "@/lib/time";
+
+function StatRow({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  icon: typeof Clock;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-secondary/30 px-4 py-3">
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Icon className="h-4 w-4" />
+        </div>
+        <span className="text-sm text-muted-foreground">{label}</span>
+      </div>
+      <span className="text-right text-sm font-semibold tabular-nums text-foreground">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function WorkoutSessionStatsPage({
+  ongoingTrainingId,
+}: {
+  ongoingTrainingId: string;
+}) {
+  const { data: ongoing } = useSuspenseQuery(
+    ongoingTrainingsQueryOptions.byId(ongoingTrainingId),
+  );
+
+  const derived = deriveWorkoutSessionStats(ongoing);
+  const isFinished = Boolean(ongoing.finishedOnUtc);
+  const trainingName = ongoing.training.name;
+
+  const durationLabel =
+    derived.actualDurationSeconds != null
+      ? formatDurationMs(derived.actualDurationSeconds * 1000)
+      : "—";
+
+  const pacingLabel =
+    derived.pacingRatioVsPlanned != null
+      ? `${Math.round(derived.pacingRatioVsPlanned * 100)}% of planned time (${ongoing.training.duration} min template)`
+      : ongoing.training.duration > 0
+        ? "—"
+        : "No planned duration on template";
+
+  const volumeLabel =
+    derived.volumeHeuristic > 0
+      ? derived.volumeHeuristic.toLocaleString(undefined, {
+          maximumFractionDigits: 1,
+        })
+      : "—";
+
+  const restLabel =
+    derived.plannedRestSecondsFromSets > 0
+      ? formatDurationMs(derived.plannedRestSecondsFromSets * 1000)
+      : "—";
+
+  return (
+    <PageCard className="max-w-2xl">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <PageTitle title="Workout stats" />
+        <Button variant="outline" size="sm" asChild>
+          <Link to="/trainings/history">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            History
+          </Link>
+        </Button>
+      </div>
+
+      {!isFinished ? (
+        <Alert className="mb-6">
+          <AlertTitle>Workout still in progress</AlertTitle>
+          <AlertDescription>
+            Timestamps and pacing reflect a session that has not finished yet. Finish the
+            workout for a complete summary.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Card className="mb-6 border-border/60">
+        <CardHeader className="pb-2">
+          <div className="flex items-start gap-3">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <BarChart3 className="h-5 w-5" />
+            </div>
+            <div>
+              <CardTitle className="text-xl leading-tight">{trainingName}</CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {ongoing.finishedOnUtc
+                  ? `Finished ${format(new Date(ongoing.finishedOnUtc), "MMM d, yyyy 'at' h:mm a")}`
+                  : `Started ${format(new Date(ongoing.startedOnUtc), "MMM d, yyyy 'at' h:mm a")}`}
+              </p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <StatRow
+            icon={Clock}
+            label="Session duration"
+            value={durationLabel}
+          />
+          {typeof ongoing.caloriesBurned === "number" ? (
+            <StatRow
+              icon={Flame}
+              label="Calories"
+              value={`${ongoing.caloriesBurned.toLocaleString()} kcal`}
+            />
+          ) : null}
+          <StatRow
+            icon={CheckCircle2}
+            label="Exercises completed / planned"
+            value={`${ongoing.completedExerciseIds?.length ?? 0} / ${derived.totalExercises}`}
+          />
+          <StatRow
+            icon={MinusCircle}
+            label="Exercises skipped"
+            value={`${derived.skippedCount}`}
+          />
+          <StatRow
+            icon={TrendingUp}
+            label="Completion rate"
+            value={`${derived.completionRatePercent.toFixed(0)}%`}
+          />
+          <StatRow
+            icon={TrendingUp}
+            label="Skip rate"
+            value={`${derived.skipRatePercent.toFixed(0)}%`}
+          />
+          <StatRow
+            icon={Layers}
+            label="Sets (completed exercises)"
+            value={`${derived.totalSetsCompleted}`}
+          />
+          <StatRow
+            icon={Dumbbell}
+            label="Volume (heuristic)"
+            value={volumeLabel}
+          />
+          <StatRow
+            icon={Timer}
+            label="Planned rest in sets (sum)"
+            value={restLabel}
+          />
+          <StatRow icon={Clock} label="Pacing vs template duration" value={pacingLabel} />
+        </CardContent>
+      </Card>
+
+      <Alert>
+        <AlertTitle>How volume and sets are counted</AlertTitle>
+        <AlertDescription>
+          Numbers use the exercise list and set rows on this session&apos;s training snapshot.
+          If you changed loads or reps during the workout, the app stores those adjustments
+          separately; a dedicated read could merge that history later for exact logged totals.
+        </AlertDescription>
+      </Alert>
+
+      <div className="mt-6 flex flex-wrap gap-2">
+        <Button variant="secondary" asChild>
+          <Link to="/trainings/workouts">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Workouts
+          </Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link
+            to="/trainings/workout-template-stats/$workoutId"
+            params={{ workoutId: ongoing.training.id }}
+          >
+            Template stats
+          </Link>
+        </Button>
+      </div>
+    </PageCard>
+  );
+}
+
+export default WorkoutSessionStatsPage;

--- a/ClientApp/src/pages/trainings/WorkoutTemplateStatsPage.tsx
+++ b/ClientApp/src/pages/trainings/WorkoutTemplateStatsPage.tsx
@@ -1,0 +1,355 @@
+import { useMemo, useState } from "react";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import type { DateRange } from "react-day-picker";
+import {
+  ArrowLeft,
+  BarChart3,
+  Calendar,
+  CheckCircle2,
+  Clock,
+  Flame,
+  Layers,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+
+import PageCard from "@/components/common/PageCard";
+import PageTitle from "@/components/common/PageTitle";
+import { DateRangeSelector } from "@/components/common/DateRangeSelector";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getDifficultyColor } from "@/features/trainings/exercises/utils/exercisesUtils";
+import { workoutHistoryQueryOptions } from "@/features/trainings/history/queries/useWorkoutHistoryQuery";
+import { trainingTemplatesUsageQueryOptions } from "@/features/trainings/overview/queries/useTrainingTemplatesUsageQuery";
+import { trainingsQueryOptions } from "@/features/trainings/trainings/queries/trainingsQueries";
+import { DateOnly, getDateOnly } from "@/lib/date";
+import { formatDurationMs } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import type { WorkoutHistoryDto } from "@/services/openapi";
+
+type ApiDateRange = {
+  startDate: DateOnly | null;
+  endDate: DateOnly | null;
+};
+
+function TemplateUsageSkeleton() {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} className="h-24 w-full rounded-lg" />
+      ))}
+    </div>
+  );
+}
+
+function WorkoutTemplateStatsPage({ workoutId }: { workoutId: string }) {
+  const { data: trainings } = useSuspenseQuery(trainingsQueryOptions.all);
+  const training = useMemo(
+    () => trainings.find((t) => t.id === workoutId),
+    [trainings, workoutId],
+  );
+
+  const [apiRange, setApiRange] = useState<ApiDateRange>(() => ({
+    startDate: getDateOnly(new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)),
+    endDate: getDateOnly(new Date()),
+  }));
+
+  const [pickerRange, setPickerRange] = useState<DateRange | undefined>(() => ({
+    from: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    to: new Date(),
+  }));
+
+  const usageQuery = useQuery(
+    trainingTemplatesUsageQueryOptions.byDateRange(
+      apiRange.startDate,
+      apiRange.endDate,
+    ),
+  );
+
+  const historyQuery = useQuery(
+    workoutHistoryQueryOptions.byDateRange(
+      apiRange.startDate,
+      apiRange.endDate,
+    ),
+  );
+
+  const usageRow = useMemo(() => {
+    const list = usageQuery.data;
+    if (!Array.isArray(list)) {
+      return undefined;
+    }
+    return list.find((row) => row.trainingId === workoutId);
+  }, [usageQuery.data, workoutId]);
+
+  const sessionsForTemplate = useMemo(() => {
+    const list = historyQuery.data;
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    return list
+      .filter((w) => w.trainingId === workoutId)
+      .sort(
+        (a, b) =>
+          new Date(b.finishedOnUtc).getTime() -
+          new Date(a.finishedOnUtc).getTime(),
+      );
+  }, [historyQuery.data, workoutId]);
+
+  const handleRangeSelect = (range: DateRange | undefined) => {
+    setPickerRange(range);
+
+    if (!range?.from || !range.to) {
+      setApiRange({
+        startDate: null,
+        endDate: null,
+      });
+      return;
+    }
+
+    setApiRange({
+      startDate: getDateOnly(range.from),
+      endDate: getDateOnly(range.to),
+    });
+  };
+
+  const blueprintStats = useMemo(() => {
+    if (!training) {
+      return null;
+    }
+    const exercises = training.exercises ?? [];
+    const totalSets = exercises.reduce(
+      (sum, ex) => sum + (ex.exerciseSets?.length ?? 0),
+      0,
+    );
+    return { exerciseCount: exercises.length, totalSets };
+  }, [training]);
+
+  if (!training || !blueprintStats) {
+    return (
+      <PageCard className="max-w-2xl">
+        <PageTitle title="Workout stats" />
+        <p className="mt-4 text-muted-foreground">
+          This workout template was not found. It may have been deleted.
+        </p>
+        <Button className="mt-6" variant="secondary" asChild>
+          <Link to="/trainings/workouts">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to workouts
+          </Link>
+        </Button>
+      </PageCard>
+    );
+  }
+
+  return (
+    <PageCard className="max-w-3xl">
+      <div className="sticky top-0 z-10 mb-6 flex flex-col gap-4 border-b border-border bg-background pb-4 sm:flex-row sm:items-center sm:justify-between">
+        <PageTitle title="Workout stats" />
+        <DateRangeSelector
+          selectedRange={pickerRange}
+          handleRangeSelect={handleRangeSelect}
+        />
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight">{training.name}</h2>
+          {training.description ? (
+            <p className="mt-1 max-w-xl text-sm text-muted-foreground">
+              {training.description}
+            </p>
+          ) : null}
+        </div>
+        <Button variant="outline" size="sm" asChild>
+          <Link
+            to="/trainings/workouts/edit/$workoutId"
+            params={{ workoutId: training.id }}
+          >
+            Edit template
+          </Link>
+        </Button>
+      </div>
+
+      <section className="mb-8">
+        <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <BarChart3 className="h-4 w-4" />
+          Usage in selected range
+        </h3>
+        {usageQuery.isPending ? (
+          <TemplateUsageSkeleton />
+        ) : usageQuery.isError ? (
+          <p className="text-sm text-destructive">Could not load usage statistics.</p>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Sessions completed
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold tabular-nums">
+                  {usageRow?.totalCompleted ?? 0}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Fully finished: {usageRow?.totalFullyCompleted ?? 0} · With skips:{" "}
+                  {usageRow?.totalWithSkippedExercises ?? 0}
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Full completion rate
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold tabular-nums">
+                  {(usageRow?.completionRate ?? 0).toFixed(1)}%
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Avg duration
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold tabular-nums">
+                  {usageRow && usageRow.averageDurationSeconds > 0
+                    ? formatDurationMs(usageRow.averageDurationSeconds * 1000)
+                    : "—"}
+                </p>
+              </CardContent>
+            </Card>
+            <Card className="border-border/60">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground">
+                  Avg calories
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-2xl font-bold tabular-nums">
+                  {typeof usageRow?.averageCaloriesBurned === "number"
+                    ? `${usageRow.averageCaloriesBurned.toLocaleString()} kcal`
+                    : "—"}
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+        {!usageQuery.isPending && !usageRow ? (
+          <p className="mt-3 text-sm text-muted-foreground">
+            No completed sessions for this template in this date range (or only templates with
+            sessions appear in usage totals).
+          </p>
+        ) : null}
+      </section>
+
+      <section className="mb-8">
+        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Template blueprint
+        </h3>
+        <Card className="border-border/60">
+          <CardContent className="flex flex-wrap gap-3 pt-6">
+            <Badge
+              variant="outline"
+              className={cn(getDifficultyColor(training.difficulty), "font-normal")}
+            >
+              {training.difficulty}
+            </Badge>
+            <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Clock className="h-4 w-4" />
+              {training.duration ? `${training.duration} min planned` : "No duration set"}
+            </span>
+            <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Layers className="h-4 w-4" />
+              {blueprintStats.exerciseCount} exercises · {blueprintStats.totalSets} sets
+            </span>
+            {training.muscleGroups?.length ? (
+              <span className="text-sm text-muted-foreground">
+                {training.muscleGroups.join(", ")}
+              </span>
+            ) : null}
+          </CardContent>
+        </Card>
+      </section>
+
+      <section>
+        <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          <Calendar className="h-4 w-4" />
+          Sessions in range
+        </h3>
+        {historyQuery.isPending ? (
+          <div className="space-y-2">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : historyQuery.isError ? (
+          <p className="text-sm text-destructive">Could not load workout history.</p>
+        ) : sessionsForTemplate.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No sessions for this template in the selected range.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {sessionsForTemplate.map((session) => (
+              <SessionRow key={session.id} session={session} />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="mt-8">
+        <Button variant="secondary" asChild>
+          <Link to="/trainings/workouts">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Workouts
+          </Link>
+        </Button>
+      </div>
+    </PageCard>
+  );
+}
+
+function SessionRow({ session }: { session: WorkoutHistoryDto }) {
+  const finishedAt = new Date(session.finishedOnUtc);
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-secondary/20 px-4 py-3">
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium">
+          {format(finishedAt, "MMM d, yyyy")} at {format(finishedAt, "h:mm a")}
+        </p>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            {session.completedExercisesCount}/{session.totalExercisesCount}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" />
+            {formatDurationMs(session.durationSeconds * 1000)}
+          </span>
+          {session.caloriesBurned != null ? (
+            <span className="flex items-center gap-1">
+              <Flame className="h-3.5 w-3.5 text-primary" />
+              {session.caloriesBurned} kcal
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <Button variant="outline" size="sm" asChild>
+        <Link
+          to="/trainings/workout-session-stats/$ongoingTrainingId"
+          params={{ ongoingTrainingId: session.id }}
+        >
+          Session stats
+        </Link>
+      </Button>
+    </li>
+  );
+}
+
+export default WorkoutTemplateStatsPage;

--- a/ClientApp/src/routeTree.gen.ts
+++ b/ClientApp/src/routeTree.gen.ts
@@ -42,6 +42,8 @@ import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeSearchDia
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeLibraryPlaylistIdRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/library.$playlistId'
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeChannelsDialogsRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/channels/_dialogs'
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsDialogsRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workouts/_dialogs'
+import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats.$workoutId'
+import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats.$ongoingTrainingId'
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-finished.$ongoingTrainingId'
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsExercisesDialogsRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/exercises/_dialogs'
 import { Route as AuthenticatedSidebarPageLayoutNavbarPageLayoutNutritionRecipesDialogsRouteImport } from './routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/nutrition/recipes/_dialogs'
@@ -299,6 +301,22 @@ const AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsDialogsRout
       id: '/_dialogs',
       getParentRoute: () =>
         AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsRoute,
+    } as any,
+  )
+const AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute =
+  AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRouteImport.update(
+    {
+      id: '/trainings/workout-template-stats/$workoutId',
+      path: '/trainings/workout-template-stats/$workoutId',
+      getParentRoute: () => AuthenticatedSidebarPageLayoutNavbarPageLayoutRoute,
+    } as any,
+  )
+const AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute =
+  AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRouteImport.update(
+    {
+      id: '/trainings/workout-session-stats/$ongoingTrainingId',
+      path: '/trainings/workout-session-stats/$ongoingTrainingId',
+      getParentRoute: () => AuthenticatedSidebarPageLayoutNavbarPageLayoutRoute,
     } as any,
   )
 const AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute =
@@ -576,6 +594,8 @@ export interface FileRoutesByFullPath {
   '/youtube/settings': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeSettingsRoute
   '/youtube/videos': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeVideosDialogsRouteWithChildren
   '/trainings/workout-finished/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute
+  '/trainings/workout-session-stats/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute
+  '/trainings/workout-template-stats/$workoutId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute
   '/youtube/library/$playlistId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeLibraryPlaylistIdRoute
   '/trainings/ongoing-workout/': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsOngoingWorkoutIndexRoute
   '/nutrition/recipes/create': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutNutritionRecipesDialogsCreateRoute
@@ -628,6 +648,8 @@ export interface FileRoutesByTo {
   '/youtube/settings': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeSettingsRoute
   '/youtube/videos': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeVideosDialogsRouteWithChildren
   '/trainings/workout-finished/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute
+  '/trainings/workout-session-stats/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute
+  '/trainings/workout-template-stats/$workoutId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute
   '/youtube/library/$playlistId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeLibraryPlaylistIdRoute
   '/trainings/ongoing-workout': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsOngoingWorkoutIndexRoute
   '/nutrition/recipes/create': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutNutritionRecipesDialogsCreateRoute
@@ -688,6 +710,8 @@ export interface FileRoutesById {
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/nutrition/recipes/_dialogs': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutNutritionRecipesDialogsRouteWithChildren
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/exercises/_dialogs': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsExercisesDialogsRouteWithChildren
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-finished/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute
+  '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats/$ongoingTrainingId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute
+  '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats/$workoutId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workouts/_dialogs': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsDialogsRouteWithChildren
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/channels/_dialogs': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeChannelsDialogsRouteWithChildren
   '/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/library/$playlistId': typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeLibraryPlaylistIdRoute
@@ -747,6 +771,8 @@ export interface FileRouteTypes {
     | '/youtube/settings'
     | '/youtube/videos'
     | '/trainings/workout-finished/$ongoingTrainingId'
+    | '/trainings/workout-session-stats/$ongoingTrainingId'
+    | '/trainings/workout-template-stats/$workoutId'
     | '/youtube/library/$playlistId'
     | '/trainings/ongoing-workout/'
     | '/nutrition/recipes/create'
@@ -799,6 +825,8 @@ export interface FileRouteTypes {
     | '/youtube/settings'
     | '/youtube/videos'
     | '/trainings/workout-finished/$ongoingTrainingId'
+    | '/trainings/workout-session-stats/$ongoingTrainingId'
+    | '/trainings/workout-template-stats/$workoutId'
     | '/youtube/library/$playlistId'
     | '/trainings/ongoing-workout'
     | '/nutrition/recipes/create'
@@ -858,6 +886,8 @@ export interface FileRouteTypes {
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/nutrition/recipes/_dialogs'
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/exercises/_dialogs'
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-finished/$ongoingTrainingId'
+    | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats/$ongoingTrainingId'
+    | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats/$workoutId'
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workouts/_dialogs'
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/channels/_dialogs'
     | '/_authenticated/_sidebarPageLayout/_navbarPageLayout/youtube/library/$playlistId'
@@ -1132,6 +1162,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/trainings/workouts'
       preLoaderRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsDialogsRouteImport
       parentRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutsRoute
+    }
+    '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats/$workoutId': {
+      id: '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats/$workoutId'
+      path: '/trainings/workout-template-stats/$workoutId'
+      fullPath: '/trainings/workout-template-stats/$workoutId'
+      preLoaderRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRouteImport
+      parentRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutRoute
+    }
+    '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats/$ongoingTrainingId': {
+      id: '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats/$ongoingTrainingId'
+      path: '/trainings/workout-session-stats/$ongoingTrainingId'
+      fullPath: '/trainings/workout-session-stats/$ongoingTrainingId'
+      preLoaderRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRouteImport
+      parentRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutRoute
     }
     '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-finished/$ongoingTrainingId': {
       id: '/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-finished/$ongoingTrainingId'
@@ -1643,6 +1687,8 @@ interface AuthenticatedSidebarPageLayoutNavbarPageLayoutRouteChildren {
   AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeSettingsRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeSettingsRoute
   AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeVideosRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeVideosRouteWithChildren
   AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute
+  AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute
+  AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute: typeof AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute
 }
 
 const AuthenticatedSidebarPageLayoutNavbarPageLayoutRouteChildren: AuthenticatedSidebarPageLayoutNavbarPageLayoutRouteChildren =
@@ -1685,6 +1731,10 @@ const AuthenticatedSidebarPageLayoutNavbarPageLayoutRouteChildren: Authenticated
       AuthenticatedSidebarPageLayoutNavbarPageLayoutYoutubeVideosRouteWithChildren,
     AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute:
       AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutFinishedOngoingTrainingIdRoute,
+    AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute:
+      AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutSessionStatsOngoingTrainingIdRoute,
+    AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute:
+      AuthenticatedSidebarPageLayoutNavbarPageLayoutTrainingsWorkoutTemplateStatsWorkoutIdRoute,
   }
 
 const AuthenticatedSidebarPageLayoutNavbarPageLayoutRouteWithChildren =

--- a/ClientApp/src/routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats.$ongoingTrainingId.tsx
+++ b/ClientApp/src/routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats.$ongoingTrainingId.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { ongoingTrainingsQueryOptions } from "@/features/trainings/ongoing-workout/queries/ongoingTrainingsQuery";
+import WorkoutSessionStatsPage from "@/pages/trainings/WorkoutSessionStatsPage";
+import { queryClient } from "@/queryClient";
+
+export const Route = createFileRoute(
+  "/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-session-stats/$ongoingTrainingId",
+)({
+  loader: ({ params }) =>
+    queryClient.ensureQueryData(
+      ongoingTrainingsQueryOptions.byId(params.ongoingTrainingId),
+    ),
+  component: function WorkoutSessionStatsRoute() {
+    const { ongoingTrainingId } = Route.useParams();
+    return <WorkoutSessionStatsPage ongoingTrainingId={ongoingTrainingId} />;
+  },
+});

--- a/ClientApp/src/routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats.$workoutId.tsx
+++ b/ClientApp/src/routes/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats.$workoutId.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { trainingsQueryOptions } from "@/features/trainings/trainings/queries/trainingsQueries";
+import WorkoutTemplateStatsPage from "@/pages/trainings/WorkoutTemplateStatsPage";
+import { queryClient } from "@/queryClient";
+
+export const Route = createFileRoute(
+  "/_authenticated/_sidebarPageLayout/_navbarPageLayout/trainings/workout-template-stats/$workoutId",
+)({
+  loader: () => queryClient.ensureQueryData(trainingsQueryOptions.all),
+  component: function WorkoutTemplateStatsRoute() {
+    const { workoutId } = Route.useParams();
+    return <WorkoutTemplateStatsPage workoutId={workoutId} />;
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds two authenticated training routes so users can inspect workout data that already exists in the API, without new backend endpoints.

**Session stats** (`/trainings/workout-session-stats/:ongoingTrainingId`): surfaces duration, optional calories, completion and skip rates, set count for completed exercises, heuristic volume (same rule as server-side performance: count1×count2 when count2 is set, else count1), sum of per-set planned rest seconds, and pacing versus the template’s planned duration. An on-page note explains that figures come from the embedded training snapshot on the session, not merged exercise history after mid-workout adjustments.

**Template stats** (`/trainings/workout-template-stats/:workoutId`): uses `getTrainingTemplatesUsage` and `getWorkoutHistory` with a date range (aligned with the history page pattern), joins the usage row for the template, shows blueprint summary, lists sessions in range with links back to session stats.

## Entry points

- Workout finished screen: “View workout stats” plus existing back action.
- Workouts list card menu: “Stats”.
- History card menu: “Workout stats”.
- Overview “Trainings completion rate” chart: click a bar to open template stats (training id carried in chart data).

## Notes

- `routeTree.gen.ts` updated by the TanStack Router Vite plugin.
- Full `npm run build` requires `VITE_HOST`, `VITE_API_PATH`, and `VITE_HIDE_TOOLS` per `ClientApp/env.ts` (unchanged project convention).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c009c6e9-e393-4ce0-afe6-ee0f90aba39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c009c6e9-e393-4ce0-afe6-ee0f90aba39f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

